### PR TITLE
feat: implement comprehensive internationalization for home page comp…

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -136,6 +136,41 @@
     "accountInfoDescription": "Displaying connected account information.",
     "notSet": "Not set"
   },
+  "Market": {
+    "pageTitle": "XRP Market",
+    "dialog": {
+      "walletBalance": "Wallet balance",
+      "amount": "Amount",
+      "transactionOverview": "Transaction overview",
+      "supplyApy": "Supply APY",
+      "collateralization": "Collateralization",
+      "healthFactor": "Health factor",
+      "bridgeFee": "Bridge fee",
+      "processing": "Processing...",
+      "supply": "Supply",
+      "error": "Error"
+    },
+    "tables": {
+      "asset": "Asset",
+      "balance": "Balance",
+      "apy": "APY",
+      "canBeCollateral": "Can be collateral",
+      "yes": "Yes",
+      "no": "No"
+    },
+    "cards": {
+      "assetsToSupply": "ASSETS TO SUPPLY",
+      "yourSupplies": "YOUR SUPPLIES",
+      "yourBorrows": "YOUR BORROWS"
+    },
+    "buttons": {
+      "supply": "Supply",
+      "withdraw": "Withdraw"
+    },
+    "messages": {
+      "connectWallet": "Please, connect your wallet"
+    }
+  },
   "History": {
     "table": {
       "date": "Date",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -136,6 +136,41 @@
     "accountInfoDescription": "接続中のアカウント情報を表示しています。",
     "notSet": "未設定"
   },
+  "Market": {
+    "pageTitle": "XRPマーケット",
+    "dialog": {
+      "walletBalance": "ウォレット残高",
+      "amount": "金額",
+      "transactionOverview": "取引概要",
+      "supplyApy": "供給APY",
+      "collateralization": "担保化",
+      "healthFactor": "ヘルスファクター",
+      "bridgeFee": "ブリッジ手数料",
+      "processing": "処理中...",
+      "supply": "供給",
+      "error": "エラー"
+    },
+    "tables": {
+      "asset": "資産",
+      "balance": "残高",
+      "apy": "APY",
+      "canBeCollateral": "担保可能",
+      "yes": "はい",
+      "no": "いいえ"
+    },
+    "cards": {
+      "assetsToSupply": "供給可能資産",
+      "yourSupplies": "あなたの供給",
+      "yourBorrows": "あなたの借入"
+    },
+    "buttons": {
+      "supply": "供給",
+      "withdraw": "引き出し"
+    },
+    "messages": {
+      "connectWallet": "ウォレットを接続してください"
+    }
+  },
   "History": {
     "table": {
       "date": "日付",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -134,6 +134,41 @@
     "accountInfoDescription": "연결된 계정 정보를 표시하고 있습니다.",
     "notSet": "설정되지 않음"
   },
+  "Market": {
+    "pageTitle": "XRP 마켓",
+    "dialog": {
+      "walletBalance": "지갑 잔액",
+      "amount": "금액",
+      "transactionOverview": "거래 개요",
+      "supplyApy": "공급 APY",
+      "collateralization": "담보화",
+      "healthFactor": "헬스 팩터",
+      "bridgeFee": "브리지 수수료",
+      "processing": "처리 중...",
+      "supply": "공급",
+      "error": "오류"
+    },
+    "tables": {
+      "asset": "자산",
+      "balance": "잔액",
+      "apy": "APY",
+      "canBeCollateral": "담보 가능",
+      "yes": "예",
+      "no": "아니오"
+    },
+    "cards": {
+      "assetsToSupply": "공급 가능한 자산",
+      "yourSupplies": "귀하의 공급",
+      "yourBorrows": "귀하의 대출"
+    },
+    "buttons": {
+      "supply": "공급",
+      "withdraw": "인출"
+    },
+    "messages": {
+      "connectWallet": "지갑을 연결해주세요"
+    }
+  },
   "History": {
     "table": {
       "date": "날짜",

--- a/frontend/src/app/[locale]/(main)/home/_components/GridAssetsToSupplyCard.tsx
+++ b/frontend/src/app/[locale]/(main)/home/_components/GridAssetsToSupplyCard.tsx
@@ -11,6 +11,7 @@ import TableContainer from '@mui/material/TableContainer'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import Typography from '@mui/material/Typography'
+import { useTranslations } from 'next-intl'
 import Button from '@/components/ui/buttons/Button'
 import Card from '@/components/ui/cards/Card'
 import Dialog from '@/app/[locale]/(main)/home/_components/dialogs/Dialog'
@@ -28,6 +29,7 @@ export default function GridAssetsToSupplyCard({
   walletBalances
 }: GridAssetsToSupplyCardProps) {
   const { isConnected } = useWallet()
+  const t = useTranslations('Market')
 
   const [token, setToken] = useState<any>(null)
   const [openDialog, setOpenDialog] = useState(false)
@@ -47,15 +49,15 @@ export default function GridAssetsToSupplyCard({
 
   return (
     <Grid size={size}>
-      <Card title="ASSETS TO SUPPLY">
+      <Card title={t('cards.assetsToSupply')}>
         <TableContainer>
           <Table aria-label="account info table">
             <TableHead>
               <TableRow>
-                <TableCell>Asset</TableCell>
-                <TableCell>Balance</TableCell>
-                <TableCell>APY</TableCell>
-                <TableCell>Can be collateral</TableCell>
+                <TableCell>{t('tables.asset')}</TableCell>
+                <TableCell>{t('tables.balance')}</TableCell>
+                <TableCell>{t('tables.apy')}</TableCell>
+                <TableCell>{t('tables.canBeCollateral')}</TableCell>
                 <TableCell></TableCell>
               </TableRow>
             </TableHead>
@@ -76,7 +78,9 @@ export default function GridAssetsToSupplyCard({
                   </TableCell>
                   <TableCell>{asset.balance}</TableCell>
                   <TableCell>{asset.apy} %</TableCell>
-                  <TableCell>{asset.collateral ? 'Yes' : 'No'}</TableCell>
+                  <TableCell>
+                    {asset.collateral ? t('tables.yes') : t('tables.no')}
+                  </TableCell>
                   <TableCell>
                     <Box sx={{ display: 'flex', gap: 1 }}>
                       <Button
@@ -86,7 +90,7 @@ export default function GridAssetsToSupplyCard({
                         disabled={asset.name !== 'XRP'}
                         onClick={() => handleOpenDialog(asset)}
                       >
-                        Supply
+                        {t('buttons.supply')}
                       </Button>
                     </Box>
                   </TableCell>
@@ -100,7 +104,7 @@ export default function GridAssetsToSupplyCard({
       <Dialog
         open={openDialog}
         onClose={handleCloseDialog}
-        title={`Supply ${token?.symbol || ''}`}
+        title={`${t('dialog.supply')} ${token?.symbol || ''}`}
         token={token}
         address={address}
       />

--- a/frontend/src/app/[locale]/(main)/home/_components/GridBorrowCard.tsx
+++ b/frontend/src/app/[locale]/(main)/home/_components/GridBorrowCard.tsx
@@ -10,6 +10,7 @@ import TableContainer from '@mui/material/TableContainer'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import Typography from '@mui/material/Typography'
+import { useTranslations } from 'next-intl'
 import Button from '@/components/ui/buttons/Button'
 import Card from '@/components/ui/cards/Card'
 import { useWallet } from '@/hooks/useWallet'
@@ -20,6 +21,7 @@ interface GridBorrowCardProps {
 
 export default function GridBorrowCard({ size }: GridBorrowCardProps) {
   const { isConnected } = useWallet()
+  const t = useTranslations('Market')
 
   if (!isConnected) {
     return null
@@ -27,14 +29,14 @@ export default function GridBorrowCard({ size }: GridBorrowCardProps) {
 
   return (
     <Grid size={size}>
-      <Card title="YOUR BORROWS">
+      <Card title={t('cards.yourBorrows')}>
         <TableContainer>
           <Table aria-label="account info table">
             <TableHead>
               <TableRow>
-                <TableCell>Asset</TableCell>
-                <TableCell>Balance</TableCell>
-                <TableCell>APY</TableCell>
+                <TableCell>{t('tables.asset')}</TableCell>
+                <TableCell>{t('tables.balance')}</TableCell>
+                <TableCell>{t('tables.apy')}</TableCell>
                 <TableCell></TableCell>
               </TableRow>
             </TableHead>
@@ -57,10 +59,10 @@ export default function GridBorrowCard({ size }: GridBorrowCardProps) {
                 <TableCell>
                   <Box sx={{ display: 'flex', gap: 1 }}>
                     <Button variant="contained" color="primary" size="small">
-                      Supply
+                      {t('buttons.supply')}
                     </Button>
                     <Button variant="outlined" color="primary" size="small">
-                      Withdraw
+                      {t('buttons.withdraw')}
                     </Button>
                   </Box>
                 </TableCell>

--- a/frontend/src/app/[locale]/(main)/home/_components/GridDisconnectCard.tsx
+++ b/frontend/src/app/[locale]/(main)/home/_components/GridDisconnectCard.tsx
@@ -2,6 +2,7 @@
 
 import Grid from '@mui/material/Grid'
 import Typography from '@mui/material/Typography'
+import { useTranslations } from 'next-intl'
 import { useWallet } from '@/hooks/useWallet'
 
 interface GridDisconnectCardProps {
@@ -10,6 +11,7 @@ interface GridDisconnectCardProps {
 
 export default function GridDisconnectCard({ size }: GridDisconnectCardProps) {
   const { isConnected } = useWallet()
+  const t = useTranslations('Market.messages')
 
   if (isConnected) {
     return null
@@ -17,7 +19,7 @@ export default function GridDisconnectCard({ size }: GridDisconnectCardProps) {
 
   return (
     <Grid size={6}>
-      <Typography variant="h6">Please, connect your wallet</Typography>
+      <Typography variant="h6">{t('connectWallet')}</Typography>
     </Grid>
   )
 }

--- a/frontend/src/app/[locale]/(main)/home/_components/GridSupplyCard.tsx
+++ b/frontend/src/app/[locale]/(main)/home/_components/GridSupplyCard.tsx
@@ -11,6 +11,7 @@ import TableContainer from '@mui/material/TableContainer'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import Typography from '@mui/material/Typography'
+import { useTranslations } from 'next-intl'
 import Button from '@/components/ui/buttons/Button'
 import Card from '@/components/ui/cards/Card'
 import { useWallet } from '@/hooks/useWallet'
@@ -26,6 +27,7 @@ export default function GridSupplyCard({
   supplyBalances
 }: GridSupplyCardProps) {
   const { isConnected } = useWallet()
+  const t = useTranslations('Market')
 
   const [openDialog, setOpenDialog] = useState(false)
 
@@ -43,14 +45,14 @@ export default function GridSupplyCard({
 
   return (
     <Grid size={size}>
-      <Card title="YOUR SUPPLIES">
+      <Card title={t('cards.yourSupplies')}>
         <TableContainer>
           <Table aria-label="account info table">
             <TableHead>
               <TableRow>
-                <TableCell>Asset</TableCell>
-                <TableCell>Balance</TableCell>
-                <TableCell>APY</TableCell>
+                <TableCell>{t('tables.asset')}</TableCell>
+                <TableCell>{t('tables.balance')}</TableCell>
+                <TableCell>{t('tables.apy')}</TableCell>
                 <TableCell></TableCell>
               </TableRow>
             </TableHead>
@@ -80,7 +82,7 @@ export default function GridSupplyCard({
                         disabled
                         onClick={() => handleOpenDialog()}
                       >
-                        Withdraw
+                        {t('buttons.withdraw')}
                       </Button>
                     </Box>
                   </TableCell>

--- a/frontend/src/app/[locale]/(main)/home/_components/dialogs/Dialog.tsx
+++ b/frontend/src/app/[locale]/(main)/home/_components/dialogs/Dialog.tsx
@@ -10,6 +10,7 @@ import InputLabel from '@mui/material/InputLabel'
 import FormControl from '@mui/material/FormControl'
 import FormHelperText from '@mui/material/FormHelperText'
 import OutlinedInput from '@mui/material/OutlinedInput'
+import { useTranslations } from 'next-intl'
 import Button from '@/components/ui/buttons/Button'
 import { createFieldValidator } from '@/utils/validation'
 import { BRDGE_GAS_FEE_AMOUT_XRP } from '@/constants/app'
@@ -32,6 +33,7 @@ export default function Dialog({
   address
 }: DialogProps) {
   const { showNotification } = useNotification()
+  const t = useTranslations('Market.dialog')
 
   const handleSuccess = () => {
     showNotification('supplySuccess', NotificationVariant.SUCCESS)
@@ -69,7 +71,7 @@ export default function Dialog({
               color="text.secondary"
               sx={{ mt: 0.5, mb: 1, textAlign: 'right' }}
             >
-              Wallet balance: {token?.balance || 0} {token?.symbol || ''}
+              {t('walletBalance')}: {token?.balance || 0} {token?.symbol || ''}
             </Typography>
             <form.Field
               name="amount"
@@ -84,9 +86,11 @@ export default function Dialog({
                   fullWidth
                   sx={{ mb: 2 }}
                 >
-                  <InputLabel htmlFor="bridge-amount-input">Amount</InputLabel>
+                  <InputLabel htmlFor="bridge-amount-input">
+                    {t('amount')}
+                  </InputLabel>
                   <OutlinedInput
-                    label="Amount"
+                    label={t('amount')}
                     id="bridge-amount-input"
                     type="text"
                     autoFocus={false}
@@ -115,7 +119,7 @@ export default function Dialog({
                     }}
                   />
                   <FormHelperText>
-                    {field.state.meta.errors.length > 0 ? 'Error' : ''}
+                    {field.state.meta.errors.length > 0 ? t('error') : ''}
                   </FormHelperText>
                 </FormControl>
               )}
@@ -123,7 +127,7 @@ export default function Dialog({
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mt: 2 }}>
             <Typography variant="subtitle2" color="text.secondary">
-              Transaction overview
+              {t('transactionOverview')}
             </Typography>
             <Box
               sx={{
@@ -136,19 +140,21 @@ export default function Dialog({
               }}
             >
               <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant="body1">Supply APY</Typography>
+                <Typography variant="body1">{t('supplyApy')}</Typography>
                 <Typography variant="body1">5%</Typography>
               </Box>
               <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant="body1">Collateralization</Typography>
+                <Typography variant="body1">
+                  {t('collateralization')}
+                </Typography>
                 <Typography variant="body1">Yes</Typography>
               </Box>
               <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant="body1">Health factor</Typography>
+                <Typography variant="body1">{t('healthFactor')}</Typography>
                 <Typography variant="body1">1.5</Typography>
               </Box>
               <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant="body1">Bridge fee</Typography>
+                <Typography variant="body1">{t('bridgeFee')}</Typography>
                 <Typography variant="body1">
                   {BRDGE_GAS_FEE_AMOUT_XRP} XRP
                 </Typography>
@@ -164,7 +170,9 @@ export default function Dialog({
               size="large"
               disabled={form.state.values.amount === '' || isLoading}
             >
-              {isLoading ? 'Processing...' : `Supply ${token?.symbol || ''}`}
+              {isLoading
+                ? t('processing')
+                : `${t('supply')} ${token?.symbol || ''}`}
             </Button>
           </Box>
         </Box>

--- a/frontend/src/app/[locale]/(main)/home/page.tsx
+++ b/frontend/src/app/[locale]/(main)/home/page.tsx
@@ -1,12 +1,15 @@
 import Grid from '@mui/material/Grid'
+import { useTranslations } from 'next-intl'
 import PageLayout from '@/components/layouts/PageLayout'
 import PageHeader from '@/components/layouts/PageHeader'
 import MainContent from '@/app/[locale]/(main)/home/_components/MainContent'
 
 export default function Home() {
+  const t = useTranslations('Market')
+
   return (
     <PageLayout maxWidth="xl">
-      <PageHeader title="XRP Market" />
+      <PageHeader title={t('pageTitle')} />
       <MainContent />
     </PageLayout>
   )


### PR DESCRIPTION
…onents

- Add Market section to translation files (en.json, ja.json, ko.json) with nested keys for cards, tables, buttons, and dialog components
- Replace hardcoded page title 'XRP Market' with t('pageTitle') in page.tsx
- Internationalize GridDisconnectCard with 'Please, connect your wallet' message
- Update GridAssetsToSupplyCard with translated card title, table headers, and buttons
- Internationalize GridSupplyCard and GridBorrowCard with proper translation keys
- Comprehensive Dialog component internationalization including form labels, transaction overview, and button text
- All components now use useTranslations hook from next-intl for proper multilingual support
- Supports English, Japanese, and Korean languages consistently across all home page components